### PR TITLE
Fixing the second, more important place where network source can get …

### DIFF
--- a/losspager/utils/admin.py
+++ b/losspager/utils/admin.py
@@ -7,6 +7,7 @@ import logging
 import os.path
 import re
 import shutil
+import sys
 import zipfile
 from distutils.spawn import find_executable
 
@@ -146,7 +147,7 @@ def transfer(
                         )
                     params["code"] = authid
                     params["eventsource"] = authsource
-                    params["eventsourcecode"] = authid.replace(authsource, "")
+                    params["eventsourcecode"] = authid[len(authsource) :]
                     params["magnitude"] = pagerdata.magnitude
                     params["latitude"] = pagerdata.latitude
                     params["longitude"] = pagerdata.longitude


### PR DESCRIPTION
…accidentally extracted from source code

The issue here came up with the event 

https://earthquake.usgs.gov/earthquakes/eventpage/us6000iust/executive

At the time of this writing, this event is missing PAGER results, because this bug mangled the "eventsourcecode" (eventid minus network), which meant that PDL could not correctly associate the PAGER product with the event.

Specifically, this bug created an eventsourcecode of "6000it" instead of "6000iust" by over-enthusiastically removing all instances of the network "us" in the eventid "us6000iust".